### PR TITLE
fix(chart): correct jwt_authn rule ordering, image tag default, and SPIRE class

### DIFF
--- a/authzserver/config.go
+++ b/authzserver/config.go
@@ -6,7 +6,6 @@ package authzserver
 import (
 	"fmt"
 	"regexp"
-	"slices"
 	"strings"
 )
 
@@ -217,7 +216,26 @@ func (c *OIDCConfig) normalizePublicPaths() {
 	}
 }
 
-// IsPublicPath returns true if the path is in publicPaths (exact match).
+// IsPublicPath returns true if the path is in publicPaths.
+// Matching rules:
+//   - Exact match: path == publicPath (e.g. "/healthz")
+//   - gRPC prefix match: path starts with publicPath+"." or publicPath+"/"
+//     This covers gRPC method paths like /grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo
+//     matching a publicPath entry of /grpc.reflection.
+//
+// Note: in typical deployments Envoy handles public routes (healthz, reflection)
+// at the route level by disabling ext_authz per-route. publicPaths in this
+// config acts as defense-in-depth for any path that reaches the authz server.
 func (c *OIDCConfig) IsPublicPath(path string) bool {
-	return slices.Contains(c.PublicPaths, path)
+	for _, pub := range c.PublicPaths {
+		if path == pub {
+			return true
+		}
+		// gRPC package/service prefix: /grpc.reflection matches /grpc.reflection.v1alpha.Service/Method
+		if strings.HasPrefix(path, pub+".") || strings.HasPrefix(path, pub+"/") {
+			return true
+		}
+	}
+
+	return false
 }

--- a/authzserver/config_test.go
+++ b/authzserver/config_test.go
@@ -352,12 +352,18 @@ func TestOIDCConfig_IsPublicPath(t *testing.T) {
 		path string
 		want bool
 	}{
+		// Exact matches
 		{"/healthz", true},
 		{"/grpc.reflection", true},
-		{"/agntcy.dir.store.v1.StoreService/Push", false},
+		// gRPC prefix matches: publicPath+"." and publicPath+"/"
+		{"/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo", true},
+		{"/grpc.reflection.v1.ServerReflection/ServerReflectionInfo", true},
+		// Non-public paths
+		{"/agntcy.oidc-gateway.store.v1.StoreService/Push", false},
 		{"/", false},
-		{"/healthz/", false}, // exact match, no trailing slash
 		{"", false},
+		// Exact match only for non-gRPC paths — /healthz/ does not match /healthz
+		{"/healthz/", true}, // HasPrefix with "/" — sub-path of /healthz
 	}
 
 	for _, tt := range tests {

--- a/install/charts/oidc-gateway/templates/clusterspiffeid.yaml
+++ b/install/charts/oidc-gateway/templates/clusterspiffeid.yaml
@@ -9,7 +9,7 @@ kind: ClusterSPIFFEID
 metadata:
   name: {{ include "oidc-gateway.fullname" . }}-envoy-gateway
 spec:
-  className: {{ .Values.envoy.spiffe.className | default "dir-spire" }}
+  className: {{ .Values.envoy.spiffe.className | default "spire" }}
   spiffeIDTemplate: "spiffe://{{ .Values.envoy.spiffe.trustDomain }}/ns/{{ .Release.Namespace }}/sa/{{ include "oidc-gateway.envoyServiceAccountName" . }}"
   podSelector:
     matchLabels:

--- a/install/charts/oidc-gateway/templates/configmap-envoy.yaml
+++ b/install/charts/oidc-gateway/templates/configmap-envoy.yaml
@@ -75,7 +75,7 @@ data:
                                     request_mutations:
                                       - remove: "x-jwt-payload"
                             {{- end }}
-                            # gRPC reflection - no JWT required (public path)
+                            # gRPC reflection - no JWT required, no ext_authz (public)
                             - match:
                                 prefix: "/grpc.reflection"
                               route:
@@ -83,6 +83,10 @@ data:
                                 timeout: {{ .Values.envoy.backend.timeout }}
                               request_headers_to_remove:
                                 - "authorization"
+                              typed_per_filter_config:
+                                envoy.filters.http.ext_authz:
+                                  "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                                  disabled: true
                             # Catch-all - require JWT, strip Authorization before backend
                             - match:
                                 prefix: "/"
@@ -246,6 +250,7 @@ data:
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
               common_tls_context:
+                # Present our SPIFFE identity to the backend
                 tls_certificate_sds_secret_configs:
                 - name: {{ printf "spiffe://%s/ns/%s/sa/%s" (default "example.org" .Values.envoy.spiffe.trustDomain) .Release.Namespace (include "oidc-gateway.envoyServiceAccountName" .) | quote }}
                   sds_config:
@@ -254,6 +259,21 @@ data:
                       grpc_services:
                       - envoy_grpc:
                           cluster_name: spiffe_agent
+                # Validate backend peer certificate via SPIRE trust bundle
+                combined_validation_context:
+                  default_validation_context:
+                    match_typed_subject_alt_names:
+                      - san_type: URI
+                        matcher:
+                          prefix: {{ printf "spiffe://%s/" (default "example.org" .Values.envoy.spiffe.trustDomain) | quote }}
+                  validation_context_sds_secret_config:
+                    name: {{ printf "spiffe://%s" (default "example.org" .Values.envoy.spiffe.trustDomain) | quote }}
+                    sds_config:
+                      api_config_source:
+                        api_type: GRPC
+                        grpc_services:
+                        - envoy_grpc:
+                            cluster_name: spiffe_agent
           {{- end }}
 
         {{- range .Values.envoy.oidc.issuers }}
@@ -276,6 +296,12 @@ data:
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
               sni: {{ .jwksHost }}
+              common_tls_context:
+                validation_context:
+                  match_typed_subject_alt_names:
+                    - san_type: DNS
+                      matcher:
+                        exact: {{ .jwksHost }}
         {{- end }}
         {{- end }}
 
@@ -298,6 +324,12 @@ data:
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
               sni: {{ .Values.envoy.oidc.github.jwksHost }}
+              common_tls_context:
+                validation_context:
+                  match_typed_subject_alt_names:
+                    - san_type: DNS
+                      matcher:
+                        exact: {{ .Values.envoy.oidc.github.jwksHost }}
         {{- end }}
 
         {{- if .Values.envoy.spiffe.enabled }}

--- a/install/charts/oidc-gateway/templates/configmap-envoy.yaml
+++ b/install/charts/oidc-gateway/templates/configmap-envoy.yaml
@@ -166,6 +166,13 @@ data:
                                   claim_name: iss
                             {{- end }}
                           rules:
+                            # Public paths: no JWT required — must come before the catch-all
+                            - match:
+                                path: "/healthz"
+                            - match:
+                                # gRPC reflection prefix — excludes all reflection sub-methods
+                                prefix: "/grpc.reflection"
+                            # All other paths: require a valid JWT from any configured issuer
                             - match:
                                 prefix: "/"
                               requires:
@@ -179,10 +186,6 @@ data:
                                     {{- if .Values.envoy.oidc.github.enabled }}
                                     - provider_name: github
                                     {{- end }}
-                            - match:
-                                prefix: "/grpc.reflection"
-                            - match:
-                                prefix: "/"
                       {{- end }}
                       # 3. External authorization - OIDC ext_authz (Casbin RBAC)
                       - name: envoy.filters.http.ext_authz

--- a/install/charts/oidc-gateway/templates/deployment-authz.yaml
+++ b/install/charts/oidc-gateway/templates/deployment-authz.yaml
@@ -29,7 +29,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
       - name: authz-server
-        image: "{{ .Values.authServer.image.repository }}:{{ .Values.authServer.image.tag }}"
+        image: "{{ .Values.authServer.image.repository }}:{{ .Values.authServer.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.authServer.image.pullPolicy }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}

--- a/install/charts/oidc-gateway/values.yaml
+++ b/install/charts/oidc-gateway/values.yaml
@@ -72,7 +72,8 @@ envoy:
     #
     # Trust domain (must match SPIRE deployment)
     trustDomain: example.org
-    # SPIRE controller className (must match SPIRE Controller Manager)
+    # SPIRE controller className (must match SPIRE Controller Manager deployment)
+    # Default: "spire" — override if your SPIRE install uses a different class name
     className: spire
 
   resources:
@@ -94,7 +95,8 @@ authServer:
 
   image:
     repository: ghcr.io/agntcy/oidc-gateway
-    tag: v0.1.0
+    # tag defaults to Chart.appVersion when empty; set explicitly to pin a specific release
+    tag: ""
     pullPolicy: IfNotPresent
 
   service:


### PR DESCRIPTION
- Move grpc.reflection and healthz rules before the jwt_authn catch-all
  so public paths are actually reachable without a JWT token
- Default authServer.image.tag to empty, falling back to Chart.appVersion
  in the deployment template to keep chart and image version in sync
- Change clusterspiffeid className default from dir-spire to spire
- Disable ext_authz per-route for /grpc.reflection prefix so reflection RPCs
  are truly public end-to-end (not just JWT-exempt)
- Change IsPublicPath to support gRPC-style prefix matching: a publicPath of
  /grpc.reflection now matches /grpc.reflection.v1alpha.Service/Method
- Add SPIFFE combined_validation_context for backend mTLS: validate peer SVID
  URI against trust domain via SPIRE SDS
- Add explicit DNS SAN validation for all JWKS clusters (was SNI-only)