### PR TITLE
feat(ci): draft release on main-only tags; document v0.1.0 and v0.1.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,32 @@ jobs:
             echo "code=${{ steps.filter.outputs.code }}" >> $GITHUB_OUTPUT
           fi
 
+  tag-on-main:
+    name: Verify tag is on main
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    outputs:
+      eligible: ${{ steps.verify.outputs.eligible }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Verify tagged commit is on main
+        id: verify
+        shell: bash
+        run: |
+          git fetch origin main --depth=1
+
+          if git merge-base --is-ancestor "$GITHUB_SHA" "origin/main"; then
+            echo "eligible=true" >> "$GITHUB_OUTPUT"
+            echo "::notice Tag ${GITHUB_REF_NAME} points to a commit on main."
+          else
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            echo "::warning Tag ${GITHUB_REF_NAME} does not point to a commit on main. Skipping release."
+          fi
+
   lint:
     name: Lint
     needs: changes
@@ -188,28 +214,15 @@ jobs:
 
   release:
     name: Release
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') && needs.tag-on-main.outputs.eligible == 'true' }}
     needs:
+      - tag-on-main
       - lint
       - license
       - test
-    uses: ./.github/workflows/reusable-build.yaml
+    uses: ./.github/workflows/reusable-release.yaml
     permissions:
-      contents: read
-      packages: write
-    with:
-      image_repo: ghcr.io/agntcy
-      image_tag: ${{ github.ref_name }}
-      push: true
-
-  helm-release:
-    name: Helm Release
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
-    needs:
-      - release
-    uses: ./.github/workflows/reusable-release-helm.yaml
-    permissions:
-      contents: read
+      contents: write
       packages: write
     with:
       image_repo: ghcr.io/agntcy
@@ -226,8 +239,8 @@ jobs:
       - build
       - push
       - helm-push-latest
+      - tag-on-main
       - release
-      - helm-release
     runs-on: ubuntu-latest
     steps:
       - name: Echo Success

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -1,0 +1,51 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+name: Release
+
+on:
+  workflow_call:
+    inputs:
+      image_repo:
+        required: true
+        type: string
+        description: "Image repo to use."
+      release_tag:
+        required: true
+        type: string
+        description: "Release tag for all components."
+
+jobs:
+  image:
+    name: Image
+    uses: ./.github/workflows/reusable-build.yaml
+    with:
+      image_repo: ${{ inputs.image_repo }}
+      image_tag: ${{ inputs.release_tag }}
+      push: true
+
+  chart:
+    name: Helm chart
+    uses: ./.github/workflows/reusable-release-helm.yaml
+    with:
+      image_repo: ${{ inputs.image_repo }}
+      release_tag: ${{ inputs.release_tag }}
+
+  release:
+    name: Release
+    needs:
+      - image
+      - chart
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create Release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ inputs.release_tag }}
+          name: Release ${{ inputs.release_tag }}
+          draft: true
+          prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,27 @@ All notable changes to the OIDC Gateway will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1] - 2026-04-21
+
+### Fixed
+
+- JWKS matching (`feat: prepare Release/v0.1.1` / #11).
+
+### Changed
+
+- Release preparation for v0.1.1 (tag: `chore: prepare release v0.1.1`).
+
+## [0.1.0] - 2026-04-21
+
+### Added
+
+- Initial OIDC Gateway service and Helm chart (`feat: migrate auth service and Helm chart from dir` / #8).
+- CI and automation: Go lint and unit tests, Docker build and push, Helm release to GHCR OCI, Renovate, and container security scan workflows (#9).
+
+### Fixed
+
+- Helm chart: correct `jwt_authn` rule ordering, default image tag, and SPIRE workload class (#10).
+- Helm chart: address deep review items for reflection, TLS validation, and public paths (#10).


### PR DESCRIPTION
Add reusable release workflow (image, Helm, draft GitHub Release), gate tag releases to commits on main, and backfill CHANGELOG entries for the two published tags.
