### PR TITLE
feat(envoy): supporting dual endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,9 @@ Important fields:
 
 The Helm chart deploys two main workloads:
 
-- Envoy, exposed on `envoy.service.port` and configured with `jwt_authn`,
-  `ext_authz`, optional SPIFFE downstream mTLS, and optional SPIFFE upstream mTLS.
+- Envoy, exposed through one or more configured `envoy.endpoints`, and configured
+  with `jwt_authn`, `ext_authz`, optional SPIFFE downstream mTLS, and optional
+  SPIFFE upstream mTLS.
 - The `oidc-gateway` authorization server, exposed internally on
   `authServer.service.port`.
 
@@ -204,21 +205,28 @@ helm install oidc-gateway oci://ghcr.io/agntcy/oidc-gateway/helm-charts/oidc-gat
 The most important values to set are:
 
 - `envoy.backend.address` and `envoy.backend.port`: upstream backend service.
+- `envoy.endpoints.oidc`: OIDC/JWT listener and service port.
+- `envoy.endpoints.mtls`: optional SPIFFE X.509-SVID listener and service port.
 - `envoy.oidc.issuers`: generic OIDC or SPIFFE JWT-SVID issuers for Envoy
   `jwt_authn`.
 - `envoy.oidc.github`: optional GitHub Actions OIDC provider shortcut.
 - `envoy.spiffe.enabled`: enables SPIFFE SDS and upstream mTLS to the backend.
-- `envoy.spiffe.downstream.enabled`: enables downstream TLS listener support for
-  SPIFFE X.509-SVID client certificates.
-- `envoy.spiffe.downstream.requireClientCertificate`: controls whether bearer-only
-  clients are still allowed.
+- `ingress.oidc`: optional OIDC/JWT ingress, normally with gRPC TLS termination.
+- `ingress.mtls`: optional SPIFFE X.509-SVID ingress, normally with TLS passthrough.
 - `authServer.oidc`: renders the authorization config consumed by the ext_authz
   server, including the principal header name Envoy strips from client requests.
 
-Minimal values example:
+Minimal OIDC/JWT endpoint example:
 
 ```yaml
 envoy:
+  endpoints:
+    oidc:
+      enabled: true
+      port: 8080
+      servicePort: 8080
+    mtls:
+      enabled: false
   backend:
     address: "directory.default.svc.cluster.local"
     port: 8888
@@ -232,9 +240,6 @@ envoy:
   spiffe:
     enabled: true
     trustDomain: example.org
-    downstream:
-      enabled: true
-      requireClientCertificate: false
 
 authServer:
   oidc:
@@ -249,6 +254,50 @@ authServer:
         allowedMethods: ["*"]
         principals:
           - "oidc:dex:admin@example.com"
+```
+
+Dual endpoint example:
+
+```yaml
+envoy:
+  endpoints:
+    oidc:
+      enabled: true
+      port: 8080
+      servicePort: 8080
+      downstreamTls:
+        enabled: false
+    mtls:
+      enabled: true
+      port: 8443
+      servicePort: 8443
+      downstreamTls:
+        enabled: true
+        requireClientCertificate: true
+  spiffe:
+    enabled: true
+    trustDomain: example.org
+
+ingress:
+  oidc:
+    enabled: true
+    host: gateway.example.com
+    annotations:
+      nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+  mtls:
+    enabled: true
+    host: mtls-gateway.example.com
+    annotations:
+      nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+      nginx.ingress.kubernetes.io/backend-protocol: "GRPCS"
+
+authServer:
+  oidc:
+    roles:
+      workloads:
+        allowedMethods: ["*"]
+        principals:
+          - "spiffe:spiffe://example.org/ns/default/sa/workload"
 ```
 
 ## Local Development

--- a/cmd/oidc-gateway/TESTING.md
+++ b/cmd/oidc-gateway/TESTING.md
@@ -77,6 +77,10 @@ Bearer JWTs and sets `x-jwt-payload` before ext_authz. This test setup passes
 `test.sh` uses `x-forwarded-client-cert` simulation, which may be rejected unless
 downstream mTLS and trusted cert handling are configured.
 
+The Helm chart can expose separate OIDC/JWT and mTLS endpoints from one Envoy
+deployment. This Docker Compose setup only exercises the single local listener
+and XFCC simulation; it does not configure real downstream SPIFFE mTLS.
+
 ## Cleanup
 
 ```bash

--- a/install/charts/oidc-gateway/templates/configmap-envoy.yaml
+++ b/install/charts/oidc-gateway/templates/configmap-envoy.yaml
@@ -3,6 +3,233 @@ Copyright AGNTCY Contributors (https://github.com/agntcy)
 SPDX-License-Identifier: Apache-2.0
 */}}
 
+{{- define "oidc-gateway.envoyListener" -}}
+{{- $root := .root -}}
+{{- $name := .name -}}
+{{- $port := .port -}}
+{{- $tlsEnabled := .tlsEnabled -}}
+{{- $requireClientCertificate := .requireClientCertificate -}}
+{{- $includeJwtAuth := .includeJwtAuth -}}
+{{- $hasIssuers := (or $root.Values.envoy.oidc.issuers $root.Values.envoy.oidc.github.enabled) -}}
+{{- if and $tlsEnabled (not $root.Values.envoy.spiffe.enabled) -}}
+{{- fail (printf "Envoy listener %s enables downstream TLS but envoy.spiffe.enabled is false" $name) -}}
+{{- end -}}
+- name: {{ $name }}
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: {{ $port }}
+  filter_chains:
+    - {{- if $tlsEnabled }}
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          require_client_certificate: {{ $requireClientCertificate }}
+          common_tls_context:
+            tls_certificate_sds_secret_configs:
+            - name: {{ printf "spiffe://%s/ns/%s/sa/%s" (default "example.org" $root.Values.envoy.spiffe.trustDomain) $root.Release.Namespace (include "oidc-gateway.envoyServiceAccountName" $root) | quote }}
+              sds_config:
+                api_config_source:
+                  api_type: GRPC
+                  grpc_services:
+                  - envoy_grpc:
+                      cluster_name: spiffe_agent
+            combined_validation_context:
+              default_validation_context:
+                match_typed_subject_alt_names:
+                  - san_type: URI
+                    matcher:
+                      prefix: {{ printf "spiffe://%s/" (default "example.org" $root.Values.envoy.spiffe.trustDomain) | quote }}
+              validation_context_sds_secret_config:
+                name: {{ printf "spiffe://%s" (default "example.org" $root.Values.envoy.spiffe.trustDomain) | quote }}
+                sds_config:
+                  api_config_source:
+                    api_type: GRPC
+                    grpc_services:
+                    - envoy_grpc:
+                        cluster_name: spiffe_agent
+      {{- end }}
+      filters:
+        - name: envoy.filters.network.http_connection_manager
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+            stat_prefix: {{ $name }}
+            codec_type: AUTO
+            http2_protocol_options: {}
+            forward_client_cert_details: APPEND_FORWARD
+            set_current_client_cert_details:
+              uri: true
+            access_log:
+              - name: envoy.access_loggers.stdout
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+            route_config:
+              name: {{ $name }}_route
+              virtual_hosts:
+                - name: backend
+                  domains: ["*"]
+                  routes:
+                    # Health check - no auth
+                    - match:
+                        path: "/healthz"
+                      direct_response:
+                        status: 200
+                        body:
+                          inline_string: '{"status":"healthy"}'
+                      typed_per_filter_config:
+                        envoy.filters.http.ext_authz:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                          disabled: true
+                    # Long-lived server-streaming RPC route (optional, configurable timeout)
+                    {{- if $root.Values.envoy.backend.streamingPath }}
+                    - match:
+                        path: {{ $root.Values.envoy.backend.streamingPath | quote }}
+                      route:
+                        cluster: backend
+                        timeout: {{ $root.Values.envoy.backend.listenRouteTimeout }}
+                      request_headers_to_remove:
+                        - "authorization"
+                      typed_per_filter_config:
+                        envoy.filters.http.header_mutation:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutationPerRoute
+                          mutations:
+                            request_mutations:
+                              - remove: "x-jwt-payload"
+                    {{- end }}
+                    # gRPC reflection - no JWT required, no ext_authz (public)
+                    - match:
+                        prefix: "/grpc.reflection"
+                      route:
+                        cluster: backend
+                        timeout: {{ $root.Values.envoy.backend.timeout }}
+                      request_headers_to_remove:
+                        - "authorization"
+                      typed_per_filter_config:
+                        envoy.filters.http.ext_authz:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                          disabled: true
+                    # Catch-all - ext_authz decides whether X.509-SVID or bearer JWT auth is present.
+                    - match:
+                        prefix: "/"
+                      route:
+                        cluster: backend
+                        timeout: {{ $root.Values.envoy.backend.timeout }}
+                      request_headers_to_remove:
+                        - "authorization"
+                      typed_per_filter_config:
+                        envoy.filters.http.header_mutation:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutationPerRoute
+                          mutations:
+                            request_mutations:
+                              - remove: "x-jwt-payload"
+            http_filters:
+              # 1. Header Mutation - strip client-supplied identity inputs (defense-in-depth)
+              - name: envoy.filters.http.header_mutation
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
+                  mutations:
+                    request_mutations:
+                      - remove: "x-jwt-payload"
+                      - remove: {{ default "x-auth-principal" $root.Values.authServer.oidc.headers.authPrincipal | quote }}
+              {{- if and $includeJwtAuth $hasIssuers }}
+              # 2. JWT Authentication - one provider per configured issuer
+              - name: envoy.filters.http.jwt_authn
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
+                  providers:
+                    {{- range $root.Values.envoy.oidc.issuers }}
+                    {{- if .enabled }}
+                    {{ .name }}:
+                      issuer: {{ .issuer | quote }}
+                      remote_jwks:
+                        http_uri:
+                          uri: {{ .jwksUri | quote }}
+                          cluster: jwks_{{ .name }}
+                          timeout: {{ $root.Values.envoy.oidc.jwksTimeout }}
+                        cache_duration:
+                          seconds: {{ $root.Values.envoy.oidc.jwksCacheSeconds }}
+                      from_headers:
+                        - name: Authorization
+                          value_prefix: 'Bearer '
+                      {{- if .audiences }}
+                      audiences:
+                        {{- range .audiences }}
+                        - {{ . | quote }}
+                        {{- end }}
+                      {{- end }}
+                      forward: true
+                      forward_payload_header: 'x-jwt-payload'
+                    {{- end }}
+                    {{- end }}
+                    {{- if $root.Values.envoy.oidc.github.enabled }}
+                    github:
+                      issuer: {{ $root.Values.envoy.oidc.github.issuer | quote }}
+                      remote_jwks:
+                        http_uri:
+                          uri: {{ $root.Values.envoy.oidc.github.jwksUri | quote }}
+                          cluster: jwks_github
+                          timeout: {{ $root.Values.envoy.oidc.jwksTimeout }}
+                        cache_duration:
+                          seconds: {{ $root.Values.envoy.oidc.jwksCacheSeconds }}
+                      from_headers:
+                        - name: Authorization
+                          value_prefix: 'Bearer '
+                      {{- if $root.Values.envoy.oidc.github.audiences }}
+                      audiences:
+                        {{- range $root.Values.envoy.oidc.github.audiences }}
+                        - {{ . | quote }}
+                        {{- end }}
+                      {{- end }}
+                      forward: true
+                      forward_payload_header: 'x-jwt-payload'
+                    {{- end }}
+                  rules:
+                    # Public paths: no JWT required — must come before the catch-all
+                    - match:
+                        path: "/healthz"
+                    - match:
+                        # gRPC reflection prefix — excludes all reflection sub-methods
+                        prefix: "/grpc.reflection"
+                    # All other paths: require a valid JWT from any configured issuer
+                    - match:
+                        prefix: "/"
+                      requires:
+                        requires_any:
+                          requirements:
+                            {{- range $root.Values.envoy.oidc.issuers }}
+                            {{- if .enabled }}
+                            - provider_name: {{ .name }}
+                            {{- end }}
+                            {{- end }}
+                            {{- if $root.Values.envoy.oidc.github.enabled }}
+                            - provider_name: github
+                            {{- end }}
+              {{- end }}
+              # 3. External authorization - OIDC ext_authz (Casbin RBAC)
+              - name: envoy.filters.http.ext_authz
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+                  transport_api_version: V3
+                  grpc_service:
+                    envoy_grpc:
+                      cluster_name: ext_authz
+                    timeout: 5s
+                  failure_mode_allow: false
+                  include_peer_certificate: true
+                  include_tls_session: true
+              # Router filter (must be last)
+              - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+{{- end -}}
+
+{{- $mtlsEnabled := .Values.envoy.endpoints.mtls.enabled -}}
+{{- $oidcPort := .Values.envoy.endpoints.oidc.port -}}
+{{- $mtlsPort := default 8443 .Values.envoy.endpoints.mtls.port -}}
+{{- $oidcTlsEnabled := .Values.envoy.endpoints.oidc.downstreamTls.enabled -}}
+{{- $oidcRequireClientCertificate := .Values.envoy.endpoints.oidc.downstreamTls.requireClientCertificate -}}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -25,216 +252,12 @@ data:
 
     static_resources:
       listeners:
-        - name: main_listener
-          address:
-            socket_address:
-              address: 0.0.0.0
-              port_value: 8080
-          filter_chains:
-            - {{- if and .Values.envoy.spiffe.enabled .Values.envoy.spiffe.downstream.enabled }}
-              transport_socket:
-                name: envoy.transport_sockets.tls
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
-                  require_client_certificate: {{ .Values.envoy.spiffe.downstream.requireClientCertificate }}
-                  common_tls_context:
-                    tls_certificate_sds_secret_configs:
-                    - name: {{ printf "spiffe://%s/ns/%s/sa/%s" (default "example.org" .Values.envoy.spiffe.trustDomain) .Release.Namespace (include "oidc-gateway.envoyServiceAccountName" .) | quote }}
-                      sds_config:
-                        api_config_source:
-                          api_type: GRPC
-                          grpc_services:
-                          - envoy_grpc:
-                              cluster_name: spiffe_agent
-                    combined_validation_context:
-                      default_validation_context:
-                        match_typed_subject_alt_names:
-                          - san_type: URI
-                            matcher:
-                              prefix: {{ printf "spiffe://%s/" (default "example.org" .Values.envoy.spiffe.trustDomain) | quote }}
-                      validation_context_sds_secret_config:
-                        name: {{ printf "spiffe://%s" (default "example.org" .Values.envoy.spiffe.trustDomain) | quote }}
-                        sds_config:
-                          api_config_source:
-                            api_type: GRPC
-                            grpc_services:
-                            - envoy_grpc:
-                                cluster_name: spiffe_agent
-              {{- end }}
-              filters:
-                - name: envoy.filters.network.http_connection_manager
-                  typed_config:
-                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                    stat_prefix: ingress_http
-                    codec_type: AUTO
-                    http2_protocol_options: {}
-                    forward_client_cert_details: APPEND_FORWARD
-                    set_current_client_cert_details:
-                      uri: true
-                    access_log:
-                      - name: envoy.access_loggers.stdout
-                        typed_config:
-                          "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
-                    route_config:
-                      name: local_route
-                      virtual_hosts:
-                        - name: backend
-                          domains: ["*"]
-                          routes:
-                            # Health check - no auth
-                            - match:
-                                path: "/healthz"
-                              direct_response:
-                                status: 200
-                                body:
-                                  inline_string: '{"status":"healthy"}'
-                              typed_per_filter_config:
-                                envoy.filters.http.ext_authz:
-                                  "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
-                                  disabled: true
-                            # Long-lived server-streaming RPC route (optional, configurable timeout)
-                            {{- if .Values.envoy.backend.streamingPath }}
-                            - match:
-                                path: {{ .Values.envoy.backend.streamingPath | quote }}
-                              route:
-                                cluster: backend
-                                timeout: {{ .Values.envoy.backend.listenRouteTimeout }}
-                              request_headers_to_remove:
-                                - "authorization"
-                              typed_per_filter_config:
-                                envoy.filters.http.header_mutation:
-                                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutationPerRoute
-                                  mutations:
-                                    request_mutations:
-                                      - remove: "x-jwt-payload"
-                            {{- end }}
-                            # gRPC reflection - no JWT required, no ext_authz (public)
-                            - match:
-                                prefix: "/grpc.reflection"
-                              route:
-                                cluster: backend
-                                timeout: {{ .Values.envoy.backend.timeout }}
-                              request_headers_to_remove:
-                                - "authorization"
-                              typed_per_filter_config:
-                                envoy.filters.http.ext_authz:
-                                  "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
-                                  disabled: true
-                            # Catch-all - require JWT, strip Authorization before backend
-                            - match:
-                                prefix: "/"
-                              route:
-                                cluster: backend
-                                timeout: {{ .Values.envoy.backend.timeout }}
-                              request_headers_to_remove:
-                                - "authorization"
-                              typed_per_filter_config:
-                                envoy.filters.http.header_mutation:
-                                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutationPerRoute
-                                  mutations:
-                                    request_mutations:
-                                      - remove: "x-jwt-payload"
-                    http_filters:
-                      # 1. Header Mutation - strip client-supplied x-jwt-payload (defense-in-depth)
-                      - name: envoy.filters.http.header_mutation
-                        typed_config:
-                          "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                          mutations:
-                            request_mutations:
-                              - remove: "x-jwt-payload"
-                              - remove: {{ default "x-auth-principal" .Values.authServer.oidc.headers.authPrincipal | quote }}
-                      {{- $hasIssuers := (or .Values.envoy.oidc.issuers .Values.envoy.oidc.github.enabled) }}
-                      {{- if $hasIssuers }}
-                      # 2. JWT Authentication - one provider per configured issuer
-                      - name: envoy.filters.http.jwt_authn
-                        typed_config:
-                          "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
-                          providers:
-                            {{- range .Values.envoy.oidc.issuers }}
-                            {{- if .enabled }}
-                            {{ .name }}:
-                              issuer: {{ .issuer | quote }}
-                              remote_jwks:
-                                http_uri:
-                                  uri: {{ .jwksUri | quote }}
-                                  cluster: jwks_{{ .name }}
-                                  timeout: {{ $.Values.envoy.oidc.jwksTimeout }}
-                                cache_duration:
-                                  seconds: {{ $.Values.envoy.oidc.jwksCacheSeconds }}
-                              from_headers:
-                                - name: Authorization
-                                  value_prefix: 'Bearer '
-                              {{- if .audiences }}
-                              audiences:
-                                {{- range .audiences }}
-                                - {{ . | quote }}
-                                {{- end }}
-                              {{- end }}
-                              forward: true
-                              forward_payload_header: 'x-jwt-payload'
-                            {{- end }}
-                            {{- end }}
-                            {{- if .Values.envoy.oidc.github.enabled }}
-                            github:
-                              issuer: {{ .Values.envoy.oidc.github.issuer | quote }}
-                              remote_jwks:
-                                http_uri:
-                                  uri: {{ .Values.envoy.oidc.github.jwksUri | quote }}
-                                  cluster: jwks_github
-                                  timeout: {{ .Values.envoy.oidc.jwksTimeout }}
-                                cache_duration:
-                                  seconds: {{ .Values.envoy.oidc.jwksCacheSeconds }}
-                              from_headers:
-                                - name: Authorization
-                                  value_prefix: 'Bearer '
-                              {{- if .Values.envoy.oidc.github.audiences }}
-                              audiences:
-                                {{- range .Values.envoy.oidc.github.audiences }}
-                                - {{ . | quote }}
-                                {{- end }}
-                              {{- end }}
-                              forward: true
-                              forward_payload_header: 'x-jwt-payload'
-                            {{- end }}
-                          rules:
-                            # Public paths: no JWT required — must come before the catch-all
-                            - match:
-                                path: "/healthz"
-                            - match:
-                                # gRPC reflection prefix — excludes all reflection sub-methods
-                                prefix: "/grpc.reflection"
-                            # All other paths: require a valid JWT from any configured issuer
-                            - match:
-                                prefix: "/"
-                              requires:
-                                requires_any:
-                                  requirements:
-                                    {{- range .Values.envoy.oidc.issuers }}
-                                    {{- if .enabled }}
-                                    - provider_name: {{ .name }}
-                                    {{- end }}
-                                    {{- end }}
-                                    {{- if .Values.envoy.oidc.github.enabled }}
-                                    - provider_name: github
-                                    {{- end }}
-                      {{- end }}
-                      # 3. External authorization - OIDC ext_authz (Casbin RBAC)
-                      - name: envoy.filters.http.ext_authz
-                        typed_config:
-                          "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
-                          transport_api_version: V3
-                          grpc_service:
-                            envoy_grpc:
-                              cluster_name: ext_authz
-                            timeout: 5s
-                          failure_mode_allow: false
-                          include_peer_certificate: true
-                          include_tls_session: true
-                      # Router filter (must be last)
-                      - name: envoy.filters.http.router
-                        typed_config:
-                          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-
+        {{- if .Values.envoy.endpoints.oidc.enabled }}
+        {{- include "oidc-gateway.envoyListener" (dict "root" . "name" "oidc_listener" "port" $oidcPort "tlsEnabled" $oidcTlsEnabled "requireClientCertificate" $oidcRequireClientCertificate "includeJwtAuth" true) | nindent 8 }}
+        {{- end }}
+        {{- if $mtlsEnabled }}
+        {{- include "oidc-gateway.envoyListener" (dict "root" . "name" "mtls_listener" "port" $mtlsPort "tlsEnabled" .Values.envoy.endpoints.mtls.downstreamTls.enabled "requireClientCertificate" .Values.envoy.endpoints.mtls.downstreamTls.requireClientCertificate "includeJwtAuth" false) | nindent 8 }}
+        {{- end }}
       clusters:
         # ExtAuthz service
         - name: ext_authz
@@ -364,4 +387,3 @@ data:
                         pipe:
                           path: /run/spire/agent-sockets/api.sock
         {{- end }}
-

--- a/install/charts/oidc-gateway/templates/deployment-envoy.yaml
+++ b/install/charts/oidc-gateway/templates/deployment-envoy.yaml
@@ -34,9 +34,16 @@ spec:
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
         ports:
-        - name: http
-          containerPort: 8080
+        {{- if .Values.envoy.endpoints.oidc.enabled }}
+        - name: oidc
+          containerPort: {{ .Values.envoy.endpoints.oidc.port }}
           protocol: TCP
+        {{- end }}
+        {{- if .Values.envoy.endpoints.mtls.enabled }}
+        - name: mtls
+          containerPort: {{ default 8443 .Values.envoy.endpoints.mtls.port }}
+          protocol: TCP
+        {{- end }}
         {{- if .Values.envoy.admin.enabled }}
         - name: admin
           containerPort: {{ .Values.envoy.admin.port }}

--- a/install/charts/oidc-gateway/templates/ingress.yaml
+++ b/install/charts/oidc-gateway/templates/ingress.yaml
@@ -3,40 +3,52 @@ Copyright AGNTCY Contributors (https://github.com/agntcy)
 SPDX-License-Identifier: Apache-2.0
 */}}
 
-{{- if .Values.ingress.enabled -}}
+{{- define "oidc-gateway.ingress" -}}
+{{- $root := .root -}}
+{{- $cfg := .config -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "oidc-gateway.fullname" . }}
+  name: {{ .name }}
   labels:
-    {{- include "oidc-gateway.envoyLabels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+    {{- include "oidc-gateway.envoyLabels" $root | nindent 4 }}
+  {{- with $cfg.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.ingress.className }}
-  ingressClassName: {{ .Values.ingress.className }}
+  {{- if $cfg.className }}
+  ingressClassName: {{ $cfg.className }}
   {{- end }}
-  {{- if .Values.ingress.tls.enabled }}
+  {{- if $cfg.tls.enabled }}
   tls:
   - hosts:
-    - {{ .Values.ingress.host }}
-    {{- if .Values.ingress.tls.secretName }}
-    secretName: {{ .Values.ingress.tls.secretName }}
-    {{- else }}
-    secretName: {{ include "oidc-gateway.fullname" . }}-tls
+    - {{ $cfg.host }}
+    {{- if $cfg.tls.secretName }}
+    secretName: {{ $cfg.tls.secretName }}
+    {{- else if .defaultSecretName }}
+    secretName: {{ include "oidc-gateway.fullname" $root }}-tls
     {{- end }}
   {{- end }}
   rules:
-  - host: {{ .Values.ingress.host }}
+  - host: {{ $cfg.host }}
     http:
       paths:
       - path: /
         pathType: Prefix
         backend:
           service:
-            name: {{ include "oidc-gateway.fullname" . }}-envoy
+            name: {{ include "oidc-gateway.fullname" $root }}-envoy
             port:
-              number: {{ .Values.envoy.service.port }}
+              number: {{ .servicePort }}
+{{- end -}}
+
+{{- $oidcServicePort := .Values.envoy.endpoints.oidc.servicePort -}}
+{{- $mtlsServicePort := default 8443 .Values.envoy.endpoints.mtls.servicePort -}}
+{{- if .Values.ingress.oidc.enabled }}
+{{ include "oidc-gateway.ingress" (dict "root" . "config" .Values.ingress.oidc "name" (printf "%s-oidc" (include "oidc-gateway.fullname" .)) "servicePort" $oidcServicePort "defaultSecretName" true) }}
+{{- end }}
+{{- if .Values.ingress.mtls.enabled }}
+---
+{{ include "oidc-gateway.ingress" (dict "root" . "config" .Values.ingress.mtls "name" (printf "%s-mtls" (include "oidc-gateway.fullname" .)) "servicePort" $mtlsServicePort "defaultSecretName" false) }}
 {{- end }}

--- a/install/charts/oidc-gateway/templates/service-envoy.yaml
+++ b/install/charts/oidc-gateway/templates/service-envoy.yaml
@@ -16,10 +16,18 @@ metadata:
 spec:
   type: {{ .Values.envoy.service.type }}
   ports:
-  - port: {{ .Values.envoy.service.port }}
-    targetPort: http
+  {{- if .Values.envoy.endpoints.oidc.enabled }}
+  - port: {{ .Values.envoy.endpoints.oidc.servicePort }}
+    targetPort: oidc
     protocol: TCP
-    name: http
+    name: oidc
+  {{- end }}
+  {{- if .Values.envoy.endpoints.mtls.enabled }}
+  - port: {{ default 8443 .Values.envoy.endpoints.mtls.servicePort }}
+    targetPort: mtls
+    protocol: TCP
+    name: mtls
+  {{- end }}
   {{- if .Values.envoy.admin.enabled }}
   - port: {{ .Values.envoy.admin.port }}
     targetPort: admin

--- a/install/charts/oidc-gateway/values.yaml
+++ b/install/charts/oidc-gateway/values.yaml
@@ -16,8 +16,25 @@ envoy:
 
   service:
     type: ClusterIP
-    port: 8080
     annotations: {}
+
+  # Downstream endpoint configuration.
+  # Enable mtls to expose a second Envoy listener for SPIFFE X.509-SVID callers.
+  endpoints:
+    oidc:
+      enabled: true
+      port: 8080
+      servicePort: 8080
+      downstreamTls:
+        enabled: false
+        requireClientCertificate: false
+    mtls:
+      enabled: false
+      port: 8443
+      servicePort: 8443
+      downstreamTls:
+        enabled: true
+        requireClientCertificate: true
 
   # Backend service configuration
   backend:
@@ -75,11 +92,6 @@ envoy:
     # SPIRE controller className (must match SPIRE Controller Manager deployment)
     # Default: "spire" — override if your SPIRE install uses a different class name
     className: spire
-    downstream:
-      # Enables downstream TLS listener support to accept SPIFFE X.509-SVID client certs.
-      enabled: false
-      # Keep false to allow bearer-only callers without client certificates.
-      requireClientCertificate: false
 
   resources:
     requests:
@@ -169,19 +181,31 @@ authServer:
       cpu: 200m
       memory: 256Mi
 
-# Ingress configuration (optional)
+# Ingress configuration (optional).
 ingress:
-  enabled: false
-  className: nginx
-  host: ""
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt
-    external-dns.alpha.kubernetes.io/hostname: ""
-    nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
-    nginx.ingress.kubernetes.io/grpc-backend: "true"
-  tls:
-    enabled: true
-    secretName: ""
+  oidc:
+    enabled: false
+    className: nginx
+    host: ""
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt
+      external-dns.alpha.kubernetes.io/hostname: ""
+      nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+      nginx.ingress.kubernetes.io/grpc-backend: "true"
+    tls:
+      enabled: true
+      secretName: ""
+  mtls:
+    enabled: false
+    className: nginx
+    host: ""
+    annotations:
+      external-dns.alpha.kubernetes.io/hostname: ""
+      nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+      nginx.ingress.kubernetes.io/backend-protocol: "GRPCS"
+    tls:
+      enabled: true
+      secretName: ""
 
 # Service account
 serviceAccount:


### PR DESCRIPTION
## Summary

**v1.0.0** already shipped unified auth (OIDC / SPIFFE JWT-SVID / X.509-SVID), the `identity` module, configurable `x-auth-principal`, and related authz config. This PR is **only** the **Helm / Envoy deployment shape**: one Envoy process, **two downstream listeners** (JWT-oriented vs client-cert mTLS), **two Service ports**, and **separate Ingress** resources—so production can use **two hostnames** without a second gateway deployment.

## What changed (since v1.0.0)

### Helm values

- **`envoy.endpoints.oidc`** — port, `servicePort`, optional downstream TLS (`requireClientCertificate` typically off).
- **`envoy.endpoints.mtls`** — second listener; downstream TLS with **`requireClientCertificate: true`** for X.509-SVID callers; **`jwt_authn` is not enabled on this listener** (identity from TLS + ext_authz).
- **`ingress.oidc`** and **`ingress.mtls`** — replace the legacy single **`ingress.*`** block (e.g. per-host TLS termination vs passthrough for mTLS).

### Templates

- **`configmap-envoy.yaml`**: shared **`oidc-gateway.envoyListener`** helper; **`static_resources.listeners`** includes `oidc_listener` and/or `mtls_listener` from the flags above.
- **`deployment-envoy.yaml`**, **`service-envoy.yaml`**, **`ingress.yaml`**: expose only the enabled endpoint ports / ingresses.

### Docs

- README and TESTING updated for the **two-endpoint** pattern and upgrade from the **v1.0.0 chart** values layout.

## Breaking changes (Helm only)

Operators who deployed **chart v1.0.0** must migrate values to **`envoy.endpoints.*`** and **`ingress.oidc` / `ingress.mtls`**. Removed: legacy single-ingress and single-listener-oriented keys from the pre–dual-endpoint chart.

**Authz container image / `authServer` OIDC YAML** for principals is unchanged in intent; this PR does not redefine the v1.0.0 principal model.

## Upgrading from chart v1.0.0

- Map the old single listener / ingress settings to **`envoy.endpoints.oidc`** (and enable **`envoy.endpoints.mtls`** + **`ingress.mtls`** only if you need the second hostname for mTLS passthrough).
- Split hostnames and annotations across **`ingress.oidc`** vs **`ingress.mtls`** per your ingress controller (gRPC backend vs TLS passthrough).

## How to test

- `helm template` / `helm lint` on `install/charts/oidc-gateway` with OIDC-only, mTLS-only, and both endpoints enabled.
- Smoke the auth paths you already validated for v1.0.0; confirm JWT flows hit the OIDC listener and cert-only flows hit the mTLS listener when both are enabled.

## Reviewer checklist

- [ ] Chart renders for OIDC-only, mTLS-only, and both endpoints.
- [ ] Ingress annotations match the target controller (gRPC / passthrough).
- [ ] SPIFFE / downstream TLS flags remain consistent with SPIRE in-cluster.
