### PR TITLE
feat: add alpn protocols for envoy

### DIFF
--- a/install/charts/oidc-gateway/templates/configmap-envoy.yaml
+++ b/install/charts/oidc-gateway/templates/configmap-envoy.yaml
@@ -27,6 +27,8 @@ SPDX-License-Identifier: Apache-2.0
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
           require_client_certificate: {{ $requireClientCertificate }}
           common_tls_context:
+            alpn_protocols:
+              - h2
             tls_certificate_sds_secret_configs:
             - name: {{ printf "spiffe://%s/ns/%s/sa/%s" (default "example.org" $root.Values.envoy.spiffe.trustDomain) $root.Release.Namespace (include "oidc-gateway.envoyServiceAccountName" $root) | quote }}
               sds_config:


### PR DESCRIPTION
Rendered chart with mTLS enabled and confirmed mtls_listener includes alpn_protocols: [h2].