### PR TITLE
feat(helm): add OpenShift install support

### DIFF
--- a/install/charts/oidc-gateway/templates/clusterspiffeid.yaml
+++ b/install/charts/oidc-gateway/templates/clusterspiffeid.yaml
@@ -9,7 +9,13 @@ kind: ClusterSPIFFEID
 metadata:
   name: {{ include "oidc-gateway.fullname" . }}-envoy-gateway
 spec:
-  className: {{ .Values.envoy.spiffe.className | default "spire" }}
+  {{- if and .Values.envoy.spiffe.className (ne .Values.envoy.spiffe.className "none") }}
+  className: {{ .Values.envoy.spiffe.className }}
+  {{- end }}
+  {{- with .Values.envoy.spiffe.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   spiffeIDTemplate: "spiffe://{{ .Values.envoy.spiffe.trustDomain }}/ns/{{ .Release.Namespace }}/sa/{{ include "oidc-gateway.envoyServiceAccountName" . }}"
   podSelector:
     matchLabels:

--- a/install/charts/oidc-gateway/templates/configmap-envoy.yaml
+++ b/install/charts/oidc-gateway/templates/configmap-envoy.yaml
@@ -387,5 +387,5 @@ data:
                   - endpoint:
                       address:
                         pipe:
-                          path: /run/spire/agent-sockets/api.sock
+                          path: /run/spire/agent-sockets/{{ .Values.envoy.spiffe.agentSocketName | default "api.sock" }}
         {{- end }}

--- a/install/charts/oidc-gateway/templates/route.yaml
+++ b/install/charts/oidc-gateway/templates/route.yaml
@@ -1,0 +1,56 @@
+{{/*
+Copyright AGNTCY Contributors (https://github.com/agntcy)
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{- if and .Values.route.oidc.enabled .Values.envoy.endpoints.oidc.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "oidc-gateway.fullname" . }}-oidc
+  labels:
+    {{- include "oidc-gateway.envoyLabels" . | nindent 4 }}
+  {{- with .Values.route.oidc.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.route.oidc.host }}
+  host: {{ .Values.route.oidc.host }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ include "oidc-gateway.fullname" . }}-envoy
+    weight: 100
+  port:
+    targetPort: oidc
+  tls:
+    termination: passthrough
+  wildcardPolicy: None
+{{- end }}
+{{- if and .Values.route.mtls.enabled .Values.envoy.endpoints.mtls.enabled }}
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "oidc-gateway.fullname" . }}-mtls
+  labels:
+    {{- include "oidc-gateway.envoyLabels" . | nindent 4 }}
+  {{- with .Values.route.mtls.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.route.mtls.host }}
+  host: {{ .Values.route.mtls.host }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ include "oidc-gateway.fullname" . }}-envoy
+    weight: 100
+  port:
+    targetPort: mtls
+  tls:
+    termination: passthrough
+  wildcardPolicy: None
+{{- end }}

--- a/install/charts/oidc-gateway/values-openshift.yaml
+++ b/install/charts/oidc-gateway/values-openshift.yaml
@@ -1,0 +1,53 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+#
+# OpenShift-specific overrides for oidc-gateway.
+# Layer on top of the default values.yaml:
+#   helm install oidc-gw <chart> -f values.yaml -f values-openshift.yaml
+#
+# Before using this overlay, determine your cluster's SPIRE configuration:
+#   oc get spireserver -A -o jsonpath='{.items[0].spec.trustDomain}'
+#   oc get clusterspiffeid -A -o yaml | grep className
+
+# Explicitly disable Ingress (OpenShift uses Routes instead)
+ingress:
+  oidc:
+    enabled: false
+  mtls:
+    enabled: false
+
+# Enable OpenShift Routes with TLS passthrough
+route:
+  oidc:
+    enabled: true
+    # host: oidc-gateway-<namespace>.apps.<cluster-domain>
+  mtls:
+    enabled: true
+    # host: oidc-gateway-mtls-<namespace>.apps.<cluster-domain>
+
+# SPIRE configuration for OpenShift
+# Adjust className and namespaceSelector based on your SPIRE operator install.
+# Discover values with:
+#   oc get clusterspiffeid -A -o yaml | grep className
+#   oc get ns <namespace> --show-labels
+envoy:
+  spiffe:
+    # Set to "none" if your SPIRE controller runs without a class.
+    # Otherwise use the className from your SPIRE install (e.g. "spire-system-spire").
+    className: "none"
+    # Scope ClusterSPIFFEID to your namespace. Required when SPIRE operator
+    # restricts registration entries by namespace label.
+    namespaceSelector: {}
+    #  matchLabels:
+    #    kubernetes.io/metadata.name: "<your-namespace>"
+    # SPIRE agent socket filename
+    agentSocketName: "spire-agent.sock"
+
+  # Enable downstream TLS on the OIDC listener.
+  # Required for TLS passthrough routes.
+  endpoints:
+    oidc:
+      downstreamTls:
+        enabled: true
+    mtls:
+      enabled: true

--- a/install/charts/oidc-gateway/values.yaml
+++ b/install/charts/oidc-gateway/values.yaml
@@ -91,7 +91,13 @@ envoy:
     trustDomain: example.org
     # SPIRE controller className (must match SPIRE Controller Manager deployment)
     # Default: "spire" — override if your SPIRE install uses a different class name
+    # Set to "none" to omit className field for classless SPIRE controllers
     className: spire
+    # Optional: restrict ClusterSPIFFEID to specific namespace(s)
+    # Required on OpenShift when SPIRE operator scopes by namespace
+    namespaceSelector: {}
+    # SPIRE agent socket filename (may differ on OpenShift managed SPIRE operators)
+    agentSocketName: api.sock
 
   resources:
     requests:
@@ -206,6 +212,18 @@ ingress:
     tls:
       enabled: true
       secretName: ""
+
+# OpenShift Route configuration (alternative to Ingress for OpenShift clusters).
+# Use TLS passthrough since Envoy handles TLS termination via SPIFFE SDS.
+route:
+  oidc:
+    enabled: false
+    host: ""
+    annotations: {}
+  mtls:
+    enabled: false
+    host: ""
+    annotations: {}
 
 # Service account
 serviceAccount:


### PR DESCRIPTION

# Description

Follow-up to agntcy/dir#1423. Adds OpenShift support to the oidc-gateway Helm chart, enabling external access via TLS passthrough Routes and configurable SPIRE integration for OpenShift environments.

@MichaelClifford's [PR #1423](https://github.com/agntcy/dir/pull/1423) to `agntcy/dir` explicitly stated: *"For full functionality with Envoy and access outside the cluster, a follow-up PR will be made to agntcy/oidc-gateway."* This PR delivers that follow-up.

## Changes

- **OpenShift Route templates (TLS passthrough):** Configurable OIDC and mTLS Routes gated by `route.oidc.enabled` and `route.mtls.enabled`. No impact on existing installs.
- **Optional className in ClusterSPIFFEID template:** Setting className to `"none"` omits the field, supporting SPIRE controllers running in classless mode. Existing default preserved.
- **Optional namespaceSelector in ClusterSPIFFEID template:** Required for managed SPIRE operators that scope workload registration by namespace. Only rendered when set via values.
- **Configurable SPIRE agent socket path:** Different SPIRE deployments may have different socket filenames (`api.sock` vs `spire-agent.sock`). Default remains `api.sock` for backward compatibility.
- **`values-openshift.yaml` overlay:** All OpenShift-specific overrides following the same two-file layering pattern established in agntcy/dir#1423.

## Usage

```bash
helm install oidc-gw ./install/charts/oidc-gateway \
  -f install/charts/oidc-gateway/values-openshift.yaml \
  --set envoy.backend.address=<dir-service>.<ns>.svc.cluster.local \
  --set envoy.spiffe.trustDomain=<trust-domain> \
  --set envoy.spiffe.className=<your-spire-class> \
  --set 'envoy.spiffe.namespaceSelector.matchLabels.kubernetes\.io/metadata\.name=<ns>'
```

## Testing

- `task lint:helm` passes with no errors
- Default template output unchanged (no regression to vanilla Kubernetes)
- Deployed on ROSA 4.19: Routes admitted with passthrough TLS, ClusterSPIFFEID registered, Envoy pod running

## Note

For full external TLS access, the SPIRE agent socket must be accessible by the Envoy container (UID 65532). This requires SPIRE agent configuration with appropriate socket permissions, consistent with the DIR chart deployment tested in agntcy/dir#1423.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/oidc-gateway/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass