### PR TITLE
feat(oidc-gateway): local ratelimits

### DIFF
--- a/install/charts/oidc-gateway/templates/_helpers.tpl
+++ b/install/charts/oidc-gateway/templates/_helpers.tpl
@@ -102,3 +102,26 @@ Envoy service account name (for SPIFFE ID)
 {{- define "oidc-gateway.envoyServiceAccountName" -}}
 {{- printf "%s-envoy-gateway" (include "oidc-gateway.fullname" .) }}
 {{- end }}
+
+{{- define "oidc-gateway.envoyLocalRateLimit" -}}
+{{- $key := .key -}}
+{{- $enabled := .enabled -}}
+{{- $bucket := .bucket -}}
+envoy.filters.http.local_ratelimit:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+  stat_prefix: {{ printf "http_local_rate_limiter_%s" $key | quote }}
+  token_bucket:
+    max_tokens: {{ $bucket.maxTokens }}
+    tokens_per_fill: {{ $bucket.tokensPerFill }}
+    fill_interval: {{ $bucket.fillInterval }}
+  filter_enabled:
+    runtime_key: {{ printf "local_rate_limit_enabled_%s" $key | quote }}
+    default_value:
+      numerator: {{ if $enabled }}100{{ else }}0{{ end }}
+      denominator: HUNDRED
+  filter_enforced:
+    runtime_key: {{ printf "local_rate_limit_enforced_%s" $key | quote }}
+    default_value:
+      numerator: 100
+      denominator: HUNDRED
+{{- end }}

--- a/install/charts/oidc-gateway/templates/configmap-envoy.yaml
+++ b/install/charts/oidc-gateway/templates/configmap-envoy.yaml
@@ -11,6 +11,7 @@ SPDX-License-Identifier: Apache-2.0
 {{- $requireClientCertificate := .requireClientCertificate -}}
 {{- $includeJwtAuth := .includeJwtAuth -}}
 {{- $hasIssuers := (or $root.Values.envoy.oidc.issuers $root.Values.envoy.oidc.github.enabled) -}}
+{{- $ratelimit := $root.Values.envoy.ratelimit -}}
 {{- if and $tlsEnabled (not $root.Values.envoy.spiffe.enabled) -}}
 {{- fail (printf "Envoy listener %s enables downstream TLS but envoy.spiffe.enabled is false" $name) -}}
 {{- end -}}
@@ -85,6 +86,24 @@ SPDX-License-Identifier: Apache-2.0
                           disabled: true
                     # Long-lived server-streaming RPC route (optional, configurable timeout)
                     {{- if $root.Values.envoy.backend.streamingPath }}
+                    # x-auth-principal header is present
+                    - match:
+                        path: {{ $root.Values.envoy.backend.streamingPath | quote }}
+                        headers:
+                          - name: x-auth-principal
+                            present_match: true
+                      route:
+                        cluster: backend
+                        timeout: {{ $root.Values.envoy.backend.listenRouteTimeout }}
+                      request_headers_to_remove:
+                        - "authorization"
+                      typed_per_filter_config:
+                        {{- include "oidc-gateway.envoyLocalRateLimit" (dict
+                          "key" "streaming_per_client"
+                          "enabled" $ratelimit.perClient.enabled
+                          "bucket" $ratelimit.perClient.tokenBucket
+                        ) | nindent 24 }}
+                    # x-auth-principal header is not present
                     - match:
                         path: {{ $root.Values.envoy.backend.streamingPath | quote }}
                       route:
@@ -93,11 +112,11 @@ SPDX-License-Identifier: Apache-2.0
                       request_headers_to_remove:
                         - "authorization"
                       typed_per_filter_config:
-                        envoy.filters.http.header_mutation:
-                          "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutationPerRoute
-                          mutations:
-                            request_mutations:
-                              - remove: "x-jwt-payload"
+                        {{- include "oidc-gateway.envoyLocalRateLimit" (dict
+                          "key" "streaming_global"
+                          "enabled" $ratelimit.global.enabled
+                          "bucket" $ratelimit.global.tokenBucket
+                        ) | nindent 24 }}
                     {{- end }}
                     # gRPC reflection - no JWT required, no ext_authz (public)
                     - match:
@@ -114,17 +133,33 @@ SPDX-License-Identifier: Apache-2.0
                     # Catch-all - ext_authz decides whether X.509-SVID or bearer JWT auth is present.
                     - match:
                         prefix: "/"
+                        headers:
+                          - name: x-auth-principal
+                            present_match: true
                       route:
                         cluster: backend
                         timeout: {{ $root.Values.envoy.backend.timeout }}
                       request_headers_to_remove:
                         - "authorization"
                       typed_per_filter_config:
-                        envoy.filters.http.header_mutation:
-                          "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutationPerRoute
-                          mutations:
-                            request_mutations:
-                              - remove: "x-jwt-payload"
+                        {{- include "oidc-gateway.envoyLocalRateLimit" (dict
+                          "key" "per_client"
+                          "enabled" $ratelimit.perClient.enabled
+                          "bucket" $ratelimit.perClient.tokenBucket
+                        ) | nindent 24 }}
+                    - match:
+                        prefix: "/"
+                      route:
+                        cluster: backend
+                        timeout: {{ $root.Values.envoy.backend.timeout }}
+                      request_headers_to_remove:
+                        - "authorization"
+                      typed_per_filter_config:
+                        {{- include "oidc-gateway.envoyLocalRateLimit" (dict
+                          "key" "global"
+                          "enabled" $ratelimit.global.enabled
+                          "bucket" $ratelimit.global.tokenBucket
+                        ) | nindent 24 }}
             http_filters:
               # 1. Header Mutation - strip client-supplied identity inputs (defense-in-depth)
               - name: envoy.filters.http.header_mutation
@@ -220,6 +255,11 @@ SPDX-License-Identifier: Apache-2.0
                   failure_mode_allow: false
                   include_peer_certificate: true
                   include_tls_session: true
+              # 4. Local rate limit after ext_authz (rate limit per x-auth-principal header)
+              - name: envoy.filters.http.local_ratelimit
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                  stat_prefix: http_local_rate_limiter
               # Router filter (must be last)
               - name: envoy.filters.http.router
                 typed_config:

--- a/install/charts/oidc-gateway/values.yaml
+++ b/install/charts/oidc-gateway/values.yaml
@@ -112,6 +112,23 @@ envoy:
     enabled: true
     port: 9901
 
+  # Rate limiting configuration
+  ratelimit:
+    # Anonymous rate limit (requests without x-auth-principal)
+    global:
+      enabled: false
+      tokenBucket:
+        maxTokens: 200
+        tokensPerFill: 200
+        fillInterval: 1s
+    # Per principal rate limit (applies to the requests of each principal)
+    perClient:
+      enabled: false
+      tokenBucket:
+        maxTokens: 1000
+        tokensPerFill: 1000
+        fillInterval: 1s
+
 # Authorization Server configuration (OIDC + Casbin)
 authServer:
   replicaCount: 1


### PR DESCRIPTION
# Description

As a first step of https://github.com/agntcy/dir/issues/904 , we should replace global rate limits and per client rate limits. This PR replaces the global rate limiter in dir (`global_rps`, `global_burst`) and the per client rate limiter (`per_client_rps`, `per_client_burst`) with an Envoy config

It behaves similarly, it also uses a token bucket algorithm. The config options are slightly different, instead of `rps` and `burst` we have `maxTokens`, `tokensPerFill` and `fillInterval`.

The global rate limiter applies to unauthenticated requests (requests without `x-auth-principal` header).
The per client limiter applies to authenticated requests (requests with `x-auth-principal` header).

Since these rate limiters depend on the `x-auth-principal` header, they are applied after the `ext-authz` filter has run. This is slightly different from the API server which rate limits based on the SPIFFE workload's ID

NB: "local" in this case means local to one Envoy instance - confusing terminology I know 😅 

## Type of Change

- [ ] Bugfix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/oidc-gateway/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
